### PR TITLE
Hotfix/18515 - [VISUALIZAÇÃO PRÉ-ANALISE] Ferramenta Exportar para PDF, opção de selecionar todos não está igual aos outros "selecionar todos"

### DIFF
--- a/src/ViewerModalExport.tsx
+++ b/src/ViewerModalExport.tsx
@@ -29,6 +29,8 @@ const ViewerModal: React.FC<ViewerModalProps> = ({ images, onClose, onSubmit, bu
       ...item,
       checked: item.id === id ? !checked : item.checked,
     }));
+    const allChecked = newItens.every(item => item.checked);
+    setSelectAll(allChecked);
     setItens(newItens);
   };
   const onChangeSelectAll = () => {


### PR DESCRIPTION
- [x] Opção "Selecionar Todos" deve entender quando eu selecionar todos um a um e a flag deve aparecer automaticamente no "Selecionar todos".
- [x] Se eu selecionei todos pela opção de "Selecionar todos" e tirei a seleção de uma imagem, a flag deve ser removida automaticamente do "Selecionar todos"