### PR TITLE
fix: modificação no icone do modal quando a tela está fullscreen

### DIFF
--- a/src/ViewerCore.tsx
+++ b/src/ViewerCore.tsx
@@ -819,10 +819,9 @@ export default class ViewerCore extends React.Component<ViewerProps, ViewerCoreS
             onClick={this.handleFullScreen}
             style={{ zIndex: zIndex + 100 }}
           >
-            <Icon type={ActionType.zoomIn} />
+            <Icon type={ !!this.state.fullScreenImage ? ActionType.zoomOut : ActionType.zoomIn }/>
           </div>
         }
-
         <ViewerCanvas
           prefixCls={this.prefixCls}
           imgAlt={activeImg.alt}


### PR DESCRIPTION
Foi ajustado o ícone de Full Screen na tela, ele estava representado com o simbolo de " + ",  porém permanecia o mesmo símbolo com a tela cheia, então alterei para o símbolo de " - " neste momento. 

![Peek 2022-02-23 15-34](https://user-images.githubusercontent.com/96294352/155386558-ebc13eeb-94b4-4d85-a16b-680565fdfeab.gif)
